### PR TITLE
Add XmlnsDefinition for Helpers namespace

### DIFF
--- a/src/Irihi.Avalonia.Shared/AssemblyInfo.cs
+++ b/src/Irihi.Avalonia.Shared/AssemblyInfo.cs
@@ -6,6 +6,7 @@ using Avalonia.Metadata;
 [assembly: XmlnsDefinition("https://irihi.tech/shared", "Irihi.Avalonia.Shared.Common")]
 [assembly: XmlnsDefinition("https://irihi.tech/shared", "Irihi.Avalonia.Shared.Contracts")]
 [assembly: XmlnsDefinition("https://irihi.tech/shared", "Irihi.Avalonia.Shared.Converters")]
+[assembly: XmlnsDefinition("https://irihi.tech/shared", "Irihi.Avalonia.Shared.Helpers")]
 [assembly: XmlnsDefinition("https://irihi.tech/shared", "Irihi.Avalonia.Shared.Property")]
 [assembly: XmlnsDefinition("https://irihi.tech/shared", "Irihi.Avalonia.Shared.MarkupExtensions")]
 [assembly: XmlnsDefinition("https://irihi.tech/shared", "Irihi.Avalonia.Shared.Shapes")]


### PR DESCRIPTION
This pull request includes a small addition to the `AssemblyInfo.cs` file. It registers a new XML namespace for the `Irihi.Avalonia.Shared.Helpers` namespace, making it available for use in XAML.