### PR TITLE
Simplify converters by introducing MarkupValueConverter

### DIFF
--- a/src/Irihi.Avalonia.Shared.Public/Converters/CornerRadiusMixerConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/CornerRadiusMixerConverter.cs
@@ -1,11 +1,9 @@
 ﻿using System.Globalization;
 using Avalonia;
-using Avalonia.Data.Converters;
-using Irihi.Avalonia.Shared.MarkupExtensions;
 
 namespace Irihi.Avalonia.Shared.Converters;
 
-public class CornerRadiusMixerConverter : IMarkupExtension<IValueConverter>, IValueConverter
+public class CornerRadiusMixerConverter : MarkupValueConverter
 {
     private readonly CornerRadiusPosition _position = CornerRadiusPosition.All;
 
@@ -18,7 +16,7 @@ public class CornerRadiusMixerConverter : IMarkupExtension<IValueConverter>, IVa
         _position = position;
     }
 
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public override object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is CornerRadius r)
         {
@@ -30,16 +28,6 @@ public class CornerRadiusMixerConverter : IMarkupExtension<IValueConverter>, IVa
         }
 
         return AvaloniaProperty.UnsetValue;
-    }
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IValueConverter ProvideValue(IServiceProvider serviceProvider)
-    {
-        return this;
     }
 }
 

--- a/src/Irihi.Avalonia.Shared.Public/Converters/MarkupValueConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/MarkupValueConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+using Avalonia.Data.Converters;
+using Irihi.Avalonia.Shared.MarkupExtensions;
+
+namespace Irihi.Avalonia.Shared.Converters;
+
+public abstract class MarkupValueConverter : IMarkupExtension<IValueConverter>, IValueConverter
+{
+    public abstract object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture);
+
+    public virtual object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IValueConverter ProvideValue(IServiceProvider _) => this;
+}

--- a/src/Irihi.Avalonia.Shared.Public/Converters/ThicknessMixerConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/ThicknessMixerConverter.cs
@@ -1,11 +1,9 @@
 ﻿using System.Globalization;
 using Avalonia;
-using Avalonia.Data.Converters;
-using Irihi.Avalonia.Shared.MarkupExtensions;
 
 namespace Irihi.Avalonia.Shared.Converters;
 
-public class ThicknessMixerConverter : IMarkupExtension<IValueConverter>, IValueConverter
+public class ThicknessMixerConverter : MarkupValueConverter
 {
     private readonly ThicknessPosition _position = ThicknessPosition.All;
 
@@ -18,7 +16,7 @@ public class ThicknessMixerConverter : IMarkupExtension<IValueConverter>, IValue
         _position = position;
     }
 
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public override object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is Thickness t)
         {
@@ -30,16 +28,6 @@ public class ThicknessMixerConverter : IMarkupExtension<IValueConverter>, IValue
         }
 
         return AvaloniaProperty.UnsetValue;
-    }
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IValueConverter ProvideValue(IServiceProvider serviceProvider)
-    {
-        return this;
     }
 }
 


### PR DESCRIPTION
This pull request refactors the value converter classes in the `Irihi.Avalonia.Shared.Public` project to reduce code duplication and improve maintainability. The main change is the introduction of a new abstract base class, `MarkupValueConverter`, which consolidates common logic for value converters that are also markup extensions. The existing `CornerRadiusMixerConverter` and `ThicknessMixerConverter` classes are updated to inherit from this new base class.

### Refactoring and codebase simplification

* Introduced a new abstract base class `MarkupValueConverter` that implements both `IMarkupExtension<IValueConverter>` and `IValueConverter`, providing default implementations for `ConvertBack` (throws `NotImplementedException`) and `ProvideValue` (returns `this`). This reduces duplication across converters.
* Updated `CornerRadiusMixerConverter` and `ThicknessMixerConverter` to inherit from `MarkupValueConverter` instead of directly implementing both interfaces, and removed now-redundant implementations of `ConvertBack` and `ProvideValue`. [[1]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL3-R6) [[2]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL3-R6)
* Changed the `Convert` methods in both converters to use the `override` keyword, reflecting the new inheritance structure. [[1]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL21-R19) [[2]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL21-R19)
* Cleaned up unused usings and removed unnecessary interface implementations from the converter files. [[1]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL3-R6) [[2]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL3-R6)
* Removed redundant code from the converters, such as explicit `ConvertBack` and `ProvideValue` methods, since these are now handled by the base class. [[1]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL34-L43) [[2]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL34-L43)