### PR TITLE
Simplify converters by introducing MarkupValueConverter

### DIFF
--- a/src/Irihi.Avalonia.Shared.Public/Converters/CornerRadiusMixerConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/CornerRadiusMixerConverter.cs
@@ -1,11 +1,9 @@
 ﻿using System.Globalization;
 using Avalonia;
-using Avalonia.Data.Converters;
-using Irihi.Avalonia.Shared.MarkupExtensions;
 
 namespace Irihi.Avalonia.Shared.Converters;
 
-public class CornerRadiusMixerConverter : IMarkupExtension<IValueConverter>, IValueConverter
+public class CornerRadiusMixerConverter : MarkupValueConverter
 {
     private readonly CornerRadiusPosition _position = CornerRadiusPosition.All;
 
@@ -18,7 +16,7 @@ public class CornerRadiusMixerConverter : IMarkupExtension<IValueConverter>, IVa
         _position = position;
     }
 
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public override object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is CornerRadius r)
         {
@@ -30,16 +28,6 @@ public class CornerRadiusMixerConverter : IMarkupExtension<IValueConverter>, IVa
         }
 
         return AvaloniaProperty.UnsetValue;
-    }
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IValueConverter ProvideValue(IServiceProvider serviceProvider)
-    {
-        return this;
     }
 }
 

--- a/src/Irihi.Avalonia.Shared.Public/Converters/MarkupValueConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/MarkupValueConverter.cs
@@ -1,0 +1,24 @@
+﻿using System.Globalization;
+using Avalonia.Data.Converters;
+using Irihi.Avalonia.Shared.MarkupExtensions;
+
+namespace Irihi.Avalonia.Shared.Converters;
+
+public abstract class MarkupValueConverter : IMarkupExtension<IValueConverter>, IValueConverter
+{
+    public abstract object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture);
+
+    public virtual object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IValueConverter ProvideValue(IServiceProvider _) => this;
+}
+
+public abstract class MarkupMultiValueConverter : IMarkupExtension<IMultiValueConverter>, IMultiValueConverter
+{
+    public abstract object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture);
+
+    public IMultiValueConverter ProvideValue(IServiceProvider _) => this;
+}

--- a/src/Irihi.Avalonia.Shared.Public/Converters/MarkupValueConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/MarkupValueConverter.cs
@@ -13,12 +13,12 @@ public abstract class MarkupValueConverter : IMarkupExtension<IValueConverter>, 
         throw new NotImplementedException();
     }
 
-    public IValueConverter ProvideValue(IServiceProvider _) => this;
+    public virtual IValueConverter ProvideValue(IServiceProvider _) => this;
 }
 
 public abstract class MarkupMultiValueConverter : IMarkupExtension<IMultiValueConverter>, IMultiValueConverter
 {
     public abstract object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture);
 
-    public IMultiValueConverter ProvideValue(IServiceProvider _) => this;
+    public virtual IMultiValueConverter ProvideValue(IServiceProvider _) => this;
 }

--- a/src/Irihi.Avalonia.Shared.Public/Converters/ThicknessMixerConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/ThicknessMixerConverter.cs
@@ -1,11 +1,9 @@
 ﻿using System.Globalization;
 using Avalonia;
-using Avalonia.Data.Converters;
-using Irihi.Avalonia.Shared.MarkupExtensions;
 
 namespace Irihi.Avalonia.Shared.Converters;
 
-public class ThicknessMixerConverter : IMarkupExtension<IValueConverter>, IValueConverter
+public class ThicknessMixerConverter : MarkupValueConverter
 {
     private readonly ThicknessPosition _position = ThicknessPosition.All;
 
@@ -18,7 +16,7 @@ public class ThicknessMixerConverter : IMarkupExtension<IValueConverter>, IValue
         _position = position;
     }
 
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public override object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is Thickness t)
         {
@@ -30,16 +28,6 @@ public class ThicknessMixerConverter : IMarkupExtension<IValueConverter>, IValue
         }
 
         return AvaloniaProperty.UnsetValue;
-    }
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IValueConverter ProvideValue(IServiceProvider serviceProvider)
-    {
-        return this;
     }
 }
 

--- a/src/Irihi.Avalonia.Shared.Public/Irihi.Avalonia.Shared.Public.projitems
+++ b/src/Irihi.Avalonia.Shared.Public/Irihi.Avalonia.Shared.Public.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\IOuterContentControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\IPopupInnerContent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\IPopupOuterContent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\MarkupValueConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\CornerRadiusMixerConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ResourceConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ThicknessMixerConverter.cs" />


### PR DESCRIPTION
This pull request refactors how value converters are implemented and reused in the project. The main improvement is the introduction of two new abstract base classes, `MarkupValueConverter` and `MarkupMultiValueConverter`, which simplify and unify the implementation of value converters. Existing converters are updated to inherit from these new base classes, reducing boilerplate and improving maintainability.

### Value Converter Abstraction

* Introduced `MarkupValueConverter` and `MarkupMultiValueConverter` abstract base classes in `MarkupValueConverter.cs`, providing reusable implementations for `IMarkupExtension` and `IValueConverter`/`IMultiValueConverter` interfaces. This centralizes common logic and enforces a consistent pattern for future converters. [[1]](diffhunk://#diff-6a880b4391bb446c87a05f6daa89379d1200632ef2b26e99961f69e98a8ffe6fR1-R24) [[2]](diffhunk://#diff-9dc197c4335d60947db76c94f83ac8d27f65ec513546c458592682e5de26024aR22)

### Refactoring Existing Converters

* Updated `CornerRadiusMixerConverter` and `ThicknessMixerConverter` to inherit from `MarkupValueConverter` instead of implementing `IMarkupExtension<IValueConverter>` and `IValueConverter` directly, removing redundant code such as explicit `ProvideValue` and `ConvertBack` implementations. [[1]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL3-R6) [[2]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL21-R19) [[3]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL34-L43) [[4]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL3-R6) [[5]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL21-R19) [[6]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL34-L43)

### Project File Update

* Added `MarkupValueConverter.cs` to the project file to ensure the new base classes are included in the build.