### PR TITLE
Add Scale Property to Thickness & CornerRadius converters

### DIFF
--- a/src/Irihi.Avalonia.Shared.Public/Converters/CornerRadiusMixerConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/CornerRadiusMixerConverter.cs
@@ -5,7 +5,9 @@ namespace Irihi.Avalonia.Shared.Converters;
 
 public class CornerRadiusMixerConverter : MarkupValueConverter
 {
-    private readonly CornerRadiusPosition _position = CornerRadiusPosition.All;
+    public CornerRadiusPosition Position { get; set; } = CornerRadiusPosition.All;
+
+    public double Scale { get; set; } = 1;
 
     public CornerRadiusMixerConverter()
     {
@@ -13,17 +15,17 @@ public class CornerRadiusMixerConverter : MarkupValueConverter
 
     public CornerRadiusMixerConverter(CornerRadiusPosition position)
     {
-        _position = position;
+        Position = position;
     }
 
     public override object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is CornerRadius r)
         {
-            double topLeft = _position.HasFlag(CornerRadiusPosition.TopLeft) ? r.TopLeft : 0;
-            double topRight = _position.HasFlag(CornerRadiusPosition.TopRight) ? r.TopRight : 0;
-            double bottomLeft = _position.HasFlag(CornerRadiusPosition.BottomLeft) ? r.BottomLeft : 0;
-            double bottomRight = _position.HasFlag(CornerRadiusPosition.BottomRight) ? r.BottomRight : 0;
+            var topLeft = Position.HasFlag(CornerRadiusPosition.TopLeft) ? r.TopLeft * Scale : 0;
+            var topRight = Position.HasFlag(CornerRadiusPosition.TopRight) ? r.TopRight * Scale : 0;
+            var bottomLeft = Position.HasFlag(CornerRadiusPosition.BottomLeft) ? r.BottomLeft * Scale : 0;
+            var bottomRight = Position.HasFlag(CornerRadiusPosition.BottomRight) ? r.BottomRight * Scale : 0;
             return new CornerRadius(topLeft, topRight, bottomRight, bottomLeft);
         }
 

--- a/src/Irihi.Avalonia.Shared.Public/Converters/ThicknessMixerConverter.cs
+++ b/src/Irihi.Avalonia.Shared.Public/Converters/ThicknessMixerConverter.cs
@@ -5,7 +5,9 @@ namespace Irihi.Avalonia.Shared.Converters;
 
 public class ThicknessMixerConverter : MarkupValueConverter
 {
-    private readonly ThicknessPosition _position = ThicknessPosition.All;
+    public ThicknessPosition Position { get; set; } = ThicknessPosition.All;
+
+    public double Scale { get; set; } = 1;
 
     public ThicknessMixerConverter()
     {
@@ -13,17 +15,17 @@ public class ThicknessMixerConverter : MarkupValueConverter
 
     public ThicknessMixerConverter(ThicknessPosition position)
     {
-        _position = position;
+        Position = position;
     }
 
     public override object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is Thickness t)
         {
-            var left = _position.HasFlag(ThicknessPosition.Left) ? t.Left : 0d;
-            var top = _position.HasFlag(ThicknessPosition.Top) ? t.Top : 0d;
-            var right = _position.HasFlag(ThicknessPosition.Right) ? t.Right : 0d;
-            var bottom = _position.HasFlag(ThicknessPosition.Bottom) ? t.Bottom : 0d;
+            var left = Position.HasFlag(ThicknessPosition.Left) ? t.Left * Scale : 0;
+            var top = Position.HasFlag(ThicknessPosition.Top) ? t.Top * Scale : 0;
+            var right = Position.HasFlag(ThicknessPosition.Right) ? t.Right * Scale : 0;
+            var bottom = Position.HasFlag(ThicknessPosition.Bottom) ? t.Bottom * Scale : 0;
             return new Thickness(left, top, right, bottom);
         }
 

--- a/test/Irihi.Avalonia.Shared.HeadlessTest/CornerRadiusMixerConverter/CornerRadiusMixerConverterTests.cs
+++ b/test/Irihi.Avalonia.Shared.HeadlessTest/CornerRadiusMixerConverter/CornerRadiusMixerConverterTests.cs
@@ -90,6 +90,33 @@ public class CornerRadiusMixerConverterTests
     }
 
     [AvaloniaFact]
+    public void CornerRadiusConverter_WithScale2_ShouldDoubleAllCorners()
+    {
+        var view = new CornerRadiusMixerConverterView();
+        var window = new Window { Content = view };
+        window.Show();
+        Assert.Equal(new CornerRadius(20, 20, 20, 20), view.button8.CornerRadius);
+    }
+
+    [AvaloniaFact]
+    public void CornerRadiusConverter_WithTopAndScaleHalf_ShouldHalveTopCorners()
+    {
+        var view = new CornerRadiusMixerConverterView();
+        var window = new Window { Content = view };
+        window.Show();
+        Assert.Equal(new CornerRadius(5, 5, 0, 0), view.button9.CornerRadius);
+    }
+
+    [AvaloniaFact]
+    public void CornerRadiusConverter_WithBottomLeftAndScaleMinus1_ShouldNegateBottomLeft()
+    {
+        var view = new CornerRadiusMixerConverterView();
+        var window = new Window { Content = view };
+        window.Show();
+        Assert.Equal(new CornerRadius(0, 0, 0, -10), view.button10.CornerRadius);
+    }
+
+    [AvaloniaFact]
     public void CornerRadiusConverter_ShouldReactToRuntimeChanges()
     {
         var view = new CornerRadiusMixerConverterView();

--- a/test/Irihi.Avalonia.Shared.HeadlessTest/CornerRadiusMixerConverter/CornerRadiusMixerConverterView.axaml
+++ b/test/Irihi.Avalonia.Shared.HeadlessTest/CornerRadiusMixerConverter/CornerRadiusMixerConverterView.axaml
@@ -27,5 +27,14 @@
         <Button
             Name="button7"
             CornerRadius="{Binding #border.CornerRadius,Converter={iri:CornerRadiusMixerConverter 'Top,Left'}}" />
+        <Button
+            Name="button8"
+            CornerRadius="{Binding #border.CornerRadius,Converter={iri:CornerRadiusMixerConverter Scale=2}}" />
+        <Button
+            Name="button9"
+            CornerRadius="{Binding #border.CornerRadius,Converter={iri:CornerRadiusMixerConverter Top,Scale=0.5}}" />
+        <Button
+            Name="button10"
+            CornerRadius="{Binding #border.CornerRadius,Converter={iri:CornerRadiusMixerConverter BottomLeft,Scale=-1}}" />
     </StackPanel>
 </UserControl>

--- a/test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterTests.cs
+++ b/test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterTests.cs
@@ -90,6 +90,33 @@ public class ThicknessMixerConverterTests
     }
 
     [AvaloniaFact]
+    public void ThicknessConverter_WithScale2_ShouldDoubleAllEdges()
+    {
+        var view = new ThicknessMixerConverterView();
+        var window = new Window { Content = view };
+        window.Show();
+        Assert.Equal(new Thickness(40), view.button8.Margin);
+    }
+
+    [AvaloniaFact]
+    public void ThicknessConverter_WithHorizontalAndScaleHalf_ShouldHalveLeftRight()
+    {
+        var view = new ThicknessMixerConverterView();
+        var window = new Window { Content = view };
+        window.Show();
+        Assert.Equal(new Thickness(10, 0, 10, 0), view.button9.Margin);
+    }
+
+    [AvaloniaFact]
+    public void ThicknessConverter_WithTopLeftAndScaleMinus1_ShouldNegateTopLeft()
+    {
+        var view = new ThicknessMixerConverterView();
+        var window = new Window { Content = view };
+        window.Show();
+        Assert.Equal(new Thickness(-20, -20, 0, 0), view.button10.Margin);
+    }
+
+    [AvaloniaFact]
     public void ThicknessConverter_ShouldReactToRuntimeChanges()
     {
         var view = new ThicknessMixerConverterView();

--- a/test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterView.axaml
+++ b/test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterView.axaml
@@ -31,5 +31,17 @@
             Name="button7"
             Padding="20"
             Margin="{Binding $self.Padding,Converter={iri:ThicknessMixerConverter 'Vertical,BottomLeft'}}" />
+        <Button
+            Name="button8"
+            Padding="20"
+            Margin="{Binding $self.Padding,Converter={iri:ThicknessMixerConverter Scale=2}}" />
+        <Button
+            Name="button9"
+            Padding="20"
+            Margin="{Binding $self.Padding,Converter={iri:ThicknessMixerConverter Horizontal,Scale=0.5}}" />
+        <Button
+            Name="button10"
+            Padding="20"
+            Margin="{Binding $self.Padding,Converter={iri:ThicknessMixerConverter TopLeft,Scale=-1}}" />
     </StackPanel>
 </UserControl>

--- a/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/CornerRadiusMixerConverterTests.cs
+++ b/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/CornerRadiusMixerConverterTests.cs
@@ -57,7 +57,7 @@ public class CornerRadiusMixerConverterTests
             Math.PI,
             new CornerRadius(1, 1, 1, 1),
             new CornerRadius(0, Math.PI, Math.PI, 0)
-        },
+        }
     };
 
     [Theory]
@@ -99,7 +99,6 @@ public class CornerRadiusMixerConverterTests
     [Fact]
     public void ConvertBack_ThrowsNotImplementedException()
     {
-        Assert.Throws<NotImplementedException>(() => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture)
-        );
+        Assert.Throws<NotImplementedException>(() => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture));
     }
 }

--- a/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/CornerRadiusMixerConverterTests.cs
+++ b/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/CornerRadiusMixerConverterTests.cs
@@ -8,54 +8,72 @@ public class CornerRadiusMixerConverterTests
 {
     private readonly CornerRadiusMixerConverter _converter = new();
 
-    public static TheoryData<CornerRadiusPosition, CornerRadius, CornerRadius> PositionTestCases => new()
+    public static TheoryData<CornerRadiusPosition, double, CornerRadius, CornerRadius> PositionTestCases => new()
     {
         {
             CornerRadiusPosition.All,
+            1,
             new CornerRadius(1, 2, 3, 4),
             new CornerRadius(1, 2, 3, 4)
         },
         {
             CornerRadiusPosition.Bottom | CornerRadiusPosition.TopRight,
+            1,
             new CornerRadius(10, 20, 30, 40),
             new CornerRadius(0, 20, 30, 40)
         },
         {
             CornerRadiusPosition.TopLeft | CornerRadiusPosition.BottomRight,
+            2,
             new CornerRadius(5, 6, 7, 8),
-            new CornerRadius(5, 0, 7, 0)
+            new CornerRadius(10, 0, 14, 0)
         },
         {
             CornerRadiusPosition.Top,
+            0.5,
             new CornerRadius(2, 3, 4, 5),
-            new CornerRadius(2, 3, 0, 0)
+            new CornerRadius(1, 1.5, 0, 0)
         },
         {
             CornerRadiusPosition.None,
+            1,
             new CornerRadius(10, 20, 30, 40),
             new CornerRadius(0)
         },
         {
             CornerRadiusPosition.BottomLeft,
+            -1,
             new CornerRadius(100, 200, 300, 400),
-            new CornerRadius(0, 0, 0, 400)
+            new CornerRadius(0, 0, 0, -400)
         },
         {
             CornerRadiusPosition.Top | CornerRadiusPosition.Left,
+            0,
             new CornerRadius(6, 7, 8, 9),
-            new CornerRadius(6, 7, 0, 9)
-        }
+            new CornerRadius(0)
+        },
+        {
+            CornerRadiusPosition.Right,
+            Math.PI,
+            new CornerRadius(1, 1, 1, 1),
+            new CornerRadius(0, Math.PI, Math.PI, 0)
+        },
     };
 
     [Theory]
     [MemberData(nameof(PositionTestCases))]
     public void Convert_WithPositionFlags_ReturnsFilteredCornerRadius(
         CornerRadiusPosition position,
+        double scale,
         CornerRadius input,
         CornerRadius expected)
     {
         // Arrange
-        var converter = new CornerRadiusMixerConverter(position);
+        var converter = new CornerRadiusMixerConverter
+        {
+            Position = position,
+            Scale = scale
+        };
 
         // Act
         var result = converter.Convert(input, typeof(CornerRadius), null, CultureInfo.InvariantCulture);
@@ -81,8 +99,7 @@ public class CornerRadiusMixerConverterTests
     [Fact]
     public void ConvertBack_ThrowsNotImplementedException()
     {
-        Assert.Throws<NotImplementedException>(
-            () => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture)
+        Assert.Throws<NotImplementedException>(() => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture)
         );
     }
 }

--- a/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/ThicknessMixerConverterTests.cs
+++ b/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/ThicknessMixerConverterTests.cs
@@ -105,7 +105,6 @@ public class ThicknessMixerConverterTests
     [Fact]
     public void ConvertBack_ThrowsNotImplementedException()
     {
-        Assert.Throws<NotImplementedException>(() => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture)
-        );
+        Assert.Throws<NotImplementedException>(() => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture));
     }
 }

--- a/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/ThicknessMixerConverterTests.cs
+++ b/test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/ThicknessMixerConverterTests.cs
@@ -8,42 +8,61 @@ public class ThicknessMixerConverterTests
 {
     private readonly ThicknessMixerConverter _converter = new();
 
-    public static TheoryData<ThicknessPosition, Thickness, Thickness> PositionTestCases => new()
+    public static TheoryData<ThicknessPosition, double, Thickness, Thickness> PositionTestCases => new()
     {
         {
             ThicknessPosition.All,
+            1,
             new Thickness(1, 2, 3, 4),
             new Thickness(1, 2, 3, 4)
         },
         {
             ThicknessPosition.Vertical | ThicknessPosition.Right,
+            1,
             new Thickness(10, 20, 30, 40),
             new Thickness(0, 20, 30, 40)
         },
         {
             ThicknessPosition.Horizontal,
+            2,
             new Thickness(5, 6, 7, 8),
-            new Thickness(5, 0, 7, 0)
+            new Thickness(10, 0, 14, 0)
         },
         {
             ThicknessPosition.TopLeft,
+            0.5,
             new Thickness(2, 3, 4, 5),
-            new Thickness(2, 3, 0, 0)
+            new Thickness(1, 1.5, 0, 0)
         },
         {
             ThicknessPosition.None,
+            1,
             new Thickness(10, 20, 30, 40),
             new Thickness(0)
         },
         {
             ThicknessPosition.Bottom,
+            0,
             new Thickness(100, 200, 300, 400),
-            new Thickness(0, 0, 0, 400)
+            new Thickness(0)
         },
         {
             ThicknessPosition.Vertical | ThicknessPosition.BottomLeft,
+            -1,
             new Thickness(6, 7, 8, 9),
-            new Thickness(6, 7, 0, 9)
+            new Thickness(-6, -7, 0, -9)
+        },
+        {
+            ThicknessPosition.TopRight,
+            20,
+            new Thickness(10, 20, 30, 40),
+            new Thickness(0, 400, 600, 0)
+        },
+        {
+            ThicknessPosition.BottomRight,
+            Math.PI,
+            new Thickness(1, 1, 1, 1),
+            new Thickness(0, 0, Math.PI, Math.PI)
         }
     };
 
@@ -51,11 +70,16 @@ public class ThicknessMixerConverterTests
     [MemberData(nameof(PositionTestCases))]
     public void Convert_WithPositionFlags_ReturnsFilteredThickness(
         ThicknessPosition position,
+        double scale,
         Thickness input,
         Thickness expected)
     {
         // Arrange
-        var converter = new ThicknessMixerConverter(position);
+        var converter = new ThicknessMixerConverter
+        {
+            Position = position,
+            Scale = scale
+        };
 
         // Act
         var result = converter.Convert(input, typeof(Thickness), null, CultureInfo.InvariantCulture);
@@ -81,8 +105,7 @@ public class ThicknessMixerConverterTests
     [Fact]
     public void ConvertBack_ThrowsNotImplementedException()
     {
-        Assert.Throws<NotImplementedException>(
-            () => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture)
+        Assert.Throws<NotImplementedException>(() => _converter.ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture)
         );
     }
 }


### PR DESCRIPTION
This pull request enhances the flexibility of both the `CornerRadiusMixerConverter` and `ThicknessMixerConverter` by introducing a new `Scale` property, allowing users to multiply selected edges or corners by a custom factor. The changes are thoroughly tested with new unit and headless tests, and the sample views are updated to demonstrate the new scaling capabilities.

### Converter enhancements

* Added a public `Scale` property to both `CornerRadiusMixerConverter` and `ThicknessMixerConverter`, enabling scaling of selected corners or edges. The `Position` property is also made public for easier configuration. The conversion logic now multiplies the selected values by `Scale`. (`src/Irihi.Avalonia.Shared.Public/Converters/CornerRadiusMixerConverter.cs` [[1]](diffhunk://#diff-a070ebdf6ad198b0a132d8608b92214c84937ca1b6c0420a776eca8e090e66aaL8-R28) `src/Irihi.Avalonia.Shared.Public/Converters/ThicknessMixerConverter.cs` [[2]](diffhunk://#diff-7828630a428543a9421a6583a7954cb52b11db19b118dfc70332a019e5496ebdL8-R28)

### Test coverage improvements

* Expanded unit tests for both converters to cover various `Scale` values, including positive, zero, negative, and non-integer factors, ensuring correctness for all edge cases. (`test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/CornerRadiusMixerConverterTests.cs` [[1]](diffhunk://#diff-8355fd299faefd9d0f2592aeb3958f65d1e6ce302a607b7cc6906e012c485349L11-R76) [[2]](diffhunk://#diff-8355fd299faefd9d0f2592aeb3958f65d1e6ce302a607b7cc6906e012c485349L84-R102) `test/Irihi.Avalonia.Shared.UnitTest.Public/Converters/ThicknessMixerConverterTests.cs` [[3]](diffhunk://#diff-933276b8b0d68285bb4ceea22d0ee0f66317cb246ea20415301c3111ef45f41eL11-R82) [[4]](diffhunk://#diff-933276b8b0d68285bb4ceea22d0ee0f66317cb246ea20415301c3111ef45f41eL84-R108)
* Added headless UI tests for scenarios using the new `Scale` property, verifying integration with Avalonia UI bindings. (`test/Irihi.Avalonia.Shared.HeadlessTest/CornerRadiusMixerConverter/CornerRadiusMixerConverterTests.cs` [[1]](diffhunk://#diff-0cd306a972434a990cf4a7366cfc039f6abe16aad09f67f376479e0ee20fd288R92-R118) `test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterTests.cs` [[2]](diffhunk://#diff-87c330995e0af570c0fa7f08bbef60b4e7aac7617422a5ba5f4a6ac110926624R92-R118)

### Demo view updates

* Updated the sample views to include new buttons demonstrating the effect of the `Scale` property with different positions and scale values. (`test/Irihi.Avalonia.Shared.HeadlessTest/CornerRadiusMixerConverter/CornerRadiusMixerConverterView.axaml` [[1]](diffhunk://#diff-9fb7f0fdd7967aadfa32bdbef82eab90da9c0b6f51d46fa30ac28e91a2b602b8R30-R38) `test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterView.axaml` [[2]](diffhunk://#diff-e43cd421a84943ccc4097570291c801e889ba0c91b375a40318226c59c49e803R34-R45)

### Miscellaneous

* Fixed a namespace in the thickness mixer converter headless test for clarity and consistency. (`test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterTests.cs` [test/Irihi.Avalonia.Shared.HeadlessTest/ThicknessMixerConverter/ThicknessMixerConverterTests.csL6-R6](diffhunk://#diff-87c330995e0af570c0fa7f08bbef60b4e7aac7617422a5ba5f4a6ac110926624L6-R6))